### PR TITLE
feat: parameterize sql run

### DIFF
--- a/langchain/src/chains/sql_db/sql_db_chain.ts
+++ b/langchain/src/chains/sql_db/sql_db_chain.ts
@@ -139,7 +139,7 @@ export class SqlDatabaseChain extends BaseChain {
     );
     let queryResult = "";
     try {
-      queryResult = await this.database.appDataSource.query(sqlCommand);
+      queryResult = await this.database.run(sqlCommand, []);
     } catch (error) {
       console.error(error);
     }
@@ -148,9 +148,7 @@ export class SqlDatabaseChain extends BaseChain {
     if (this.returnDirect) {
       finalResult = { [this.outputKey]: queryResult };
     } else {
-      inputText += `${sqlCommand}\nSQLResult: ${JSON.stringify(
-        queryResult
-      )}\nAnswer:`;
+      inputText += `${sqlCommand}\nSQLResult: ${queryResult}\nAnswer:`;
       llmInputs.input = inputText;
       finalResult = {
         [this.outputKey]: await llmChain.predict(

--- a/langchain/src/tests/sql_database.int.test.ts
+++ b/langchain/src/tests/sql_database.int.test.ts
@@ -130,7 +130,7 @@ test("Test run", async () => {
   const db = await SqlDatabase.fromDataSourceParams({
     appDataSource: datasource,
   });
-  const result = await db.run("SELECT * FROM users");
+  const result = await db.run("SELECT * FROM users WHERE age > ?", [19]);
   const expectStr = `[{"id":1,"name":"Alice","age":20},{"id":2,"name":"Bob","age":21},{"id":3,"name":"Charlie","age":22}]`;
   expect(result.trim()).toBe(expectStr.trim());
 });
@@ -140,7 +140,7 @@ test("Test run with error", async () => {
     const db = await SqlDatabase.fromDataSourceParams({
       appDataSource: datasource,
     });
-    await db.run("SELECT * FROM userss");
+    await db.run("SELECT * FROM userss WHERE id = ?", [1]);
   }).rejects.toThrow("SQLITE_ERROR: no such table: userss");
 });
 

--- a/langchain/src/tools/sql.ts
+++ b/langchain/src/tools/sql.ts
@@ -37,7 +37,7 @@ export class QuerySqlTool extends Tool implements SqlTool {
   /** @ignore */
   async _call(input: string) {
     try {
-      return await this.db.run(input);
+      return await this.db.run(input, []);
     } catch (error) {
       return `${error}`;
     }


### PR DESCRIPTION
## Summary
- require whitelisted verbs and placeholders in SqlDatabase.run
- pass value arrays in SQL chain, tools, and tests

## Testing
- `yarn workspace langchain lint`
- `yarn workspace langchain test` *(fails: Cannot find module '@langchain/core/callbacks/promises')*

------
